### PR TITLE
Fix: Inconsistent contract state after cancellation

### DIFF
--- a/contracts/ReversibleICO.sol
+++ b/contracts/ReversibleICO.sol
@@ -1135,6 +1135,17 @@ contract ReversibleICO is IERC777Recipient {
         aggregatedStats.reservedTokens = 0;
         aggregatedStats.withdrawnETH = aggregatedStats.withdrawnETH.add(participantAvailableETH);
 
+        uint8 currentStage = getCurrentStage();
+        for (uint8 stageId = 0; stageId <= currentStage; stageId++) {
+            ParticipantDetails storage state = participantRecord.byStage[stageId];
+            uint256 stageAvailableETH = state.totalReceivedETH
+                .sub(state.returnedETH)
+                .sub(state.committedETH)
+                .sub(state.withdrawnETH);
+            state.reservedTokens = 0;
+            state.withdrawnETH = state.withdrawnETH.add(stageAvailableETH);
+        }
+
         // transfer ETH back to participant including received value
         address(uint160(_from)).transfer(participantAvailableETH.add(_value));
 


### PR DESCRIPTION
Cancellation of a contribution results in an inconsistent state. The `aggregatedState` does not match the sums of the `byStage` values.

### Scenario
- Contributor buys 100 Tokens.
- Contributor cancels contribution.
- Contract state gets updated:
  - Only `aggregatedState` gets updated.
  - State `byStage` stays the same.
- Participant can still send further contributions.
- However, an error occurs as soon as participant gets whitelisted:
  - `aggregatedStats.reservedTokens.sub(byStage.reservedTokens);` results in underflow.