### PR TITLE
Check global state after cancelled contribution

### DIFF
--- a/contracts/ReversibleICO.sol
+++ b/contracts/ReversibleICO.sol
@@ -1133,7 +1133,7 @@ contract ReversibleICO is IERC777Recipient {
 
         // update participant's audit values
         aggregatedStats.reservedTokens = 0;
-        aggregatedStats.withdrawnETH = aggregatedStats.withdrawnETH.add(participantAvailableETH);
+        aggregatedStats.returnedETH = aggregatedStats.withdrawnETH.add(participantAvailableETH);
 
         uint8 currentStage = getCurrentStage();
         for (uint8 stageId = 0; stageId <= currentStage; stageId++) {
@@ -1143,7 +1143,7 @@ contract ReversibleICO is IERC777Recipient {
                 .sub(state.committedETH)
                 .sub(state.withdrawnETH);
             state.reservedTokens = 0;
-            state.withdrawnETH = state.withdrawnETH.add(stageAvailableETH);
+            state.returnedETH = state.withdrawnETH.add(stageAvailableETH);
         }
 
         // transfer ETH back to participant including received value


### PR DESCRIPTION
Cancellation adds the returned amount to the global `returnedETH`.

However, for the `aggregatedState` and the `byStageState` the amount is added to `withdrawnETH`. This leads to an inconcistent state and miscalculations during accept.