### PR TITLE
Cancelling before white-listing should not deliver too many tokens later

### DIFF
--- a/contracts/ReversibleICO.sol
+++ b/contracts/ReversibleICO.sol
@@ -1133,7 +1133,7 @@ contract ReversibleICO is IERC777Recipient {
 
         // update participant's audit values
         aggregatedStats.reservedTokens = 0;
-        aggregatedStats.withdrawnETH = aggregatedStats.withdrawnETH.add(participantAvailableETH);
+        aggregatedStats.returnedETH = aggregatedStats.withdrawnETH.add(participantAvailableETH);
 
         uint8 currentStage = getCurrentStage();
         for (uint8 stageId = 0; stageId <= currentStage; stageId++) {
@@ -1143,7 +1143,7 @@ contract ReversibleICO is IERC777Recipient {
                 .sub(state.committedETH)
                 .sub(state.withdrawnETH);
             state.reservedTokens = 0;
-            state.withdrawnETH = state.withdrawnETH.add(stageAvailableETH);
+            state.returnedETH = state.withdrawnETH.add(stageAvailableETH);
         }
 
         // transfer ETH back to participant including received value

--- a/contracts/ReversibleICO.sol
+++ b/contracts/ReversibleICO.sol
@@ -1046,7 +1046,7 @@ contract ReversibleICO is IERC777Recipient {
                 uint256 maxAcceptableValue = availableEthAtStage(currentStage);
 
                 // the per stage accepted amount: totalReceivedETH - committedETH
-                uint256 newAcceptedValue = byStage.totalReceivedETH.sub(byStage.committedETH);
+                uint256 newAcceptedValue = byStage.totalReceivedETH.sub(byStage.committedETH).sub(byStage.returnedETH);
                 uint256 returnValue;
 
                 if (newAcceptedValue > 0) {
@@ -1054,9 +1054,8 @@ contract ReversibleICO is IERC777Recipient {
                     // if incomming value is higher than what we can accept,
                     // just accept the difference and return the rest
                     if (newAcceptedValue > maxAcceptableValue) {
+                        returnValue = newAcceptedValue.sub(maxAcceptableValue);
                         newAcceptedValue = maxAcceptableValue;
-                        returnValue = byStage.totalReceivedETH.sub(byStage.returnedETH).sub(byStage.committedETH)
-                        .sub(byStage.withdrawnETH).sub(newAcceptedValue);
 
                         // update return values
                         returnedETH = returnedETH.add(returnValue);


### PR DESCRIPTION
Accepting tokens calculated wrong pending ETH amount (`newAcceptedValue`). The `returnedETH` amount is not taken into account which leads to delivery of too many tokens.