### PR TITLE
Fix cancellation test `value < rico.minContribution results in cancel(value), account has 2 contributions`

### DIFF
--- a/test/solc_tests/5_Cancel.js
+++ b/test/solc_tests/5_Cancel.js
@@ -488,7 +488,7 @@ describe("Testing canceling", function () {
                 for(let i = 0; i < StageCount; i++) {
                     const ParticipantStageDetails = await ReversibleICOInstance.methods.getParticipantDetailsByStage(participant_1, i).call();
                     ContributionTotals = ContributionTotals.add(new helpers.BN(
-                        ParticipantStageDetails.stageCommittedETH
+                        ParticipantStageDetails.stageTotalReceivedETH
                     ));
                 }
 


### PR DESCRIPTION
Test used old old `ParticipantStageDetails` name.